### PR TITLE
Move key-value store out-of-tree

### DIFF
--- a/kv/delete.go
+++ b/kv/delete.go
@@ -1,0 +1,54 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+import (
+	"time"
+)
+
+// Delete marks secret versions as deleted for a given path. If no versions are
+// specified, it marks only the current version as deleted. If specific versions
+// are provided, it marks each existing version in the list as deleted. The
+// deletion is performed by setting the DeletedTime to the current time. If the
+// path doesn't exist, the function returns without making any changes.
+func (kv *KV) Delete(path string, versions []int) error {
+	secret, exists := kv.data[path]
+	if !exists {
+		return ErrItemNotFound
+	}
+
+	now := time.Now()
+	cv := secret.Metadata.CurrentVersion
+
+	// If no versions specified, mark the latest version as deleted
+	if len(versions) == 0 {
+
+		if v, exists := secret.Versions[cv]; exists {
+			v.DeletedTime = &now // Mark as deleted.
+			secret.Versions[cv] = v
+		}
+		return nil
+	}
+
+	// Delete specific versions
+	for _, version := range versions {
+		if version == 0 {
+			v, exists := secret.Versions[cv]
+			if !exists {
+				continue
+			}
+
+			v.DeletedTime = &now // Mark as deleted.
+			secret.Versions[cv] = v
+			continue
+		}
+
+		if v, exists := secret.Versions[version]; exists {
+			v.DeletedTime = &now // Mark as deleted.
+			secret.Versions[version] = v
+		}
+	}
+	return nil
+}

--- a/kv/delete_test.go
+++ b/kv/delete_test.go
@@ -1,0 +1,120 @@
+package kv
+
+import (
+	"testing"
+)
+
+func TestKV_Delete(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *KV
+		path     string
+		versions []int
+		wantErr  error
+	}{
+		{
+			name: "non_existent_path",
+			setup: func() *KV {
+				return &KV{
+					data: make(map[string]*Secret),
+				}
+			},
+			path:     "non/existent/path",
+			versions: nil,
+			wantErr:  ErrItemNotFound,
+		},
+		{
+			name: "delete_current_version_no_versions_specified",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "test_value",
+							},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: nil,
+			wantErr:  nil,
+		},
+		{
+			name: "delete_specific_versions",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 2,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "value1",
+							},
+						},
+						2: {
+							Data: map[string]string{
+								"key": "value2",
+							},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: []int{1, 2},
+			wantErr:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			err := kv.Delete(tt.path, tt.versions)
+
+			if err != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == nil {
+				secret, exists := kv.data[tt.path]
+				if !exists {
+					t.Errorf("Secret should still exist after deletion")
+					return
+				}
+
+				if len(tt.versions) == 0 {
+					cv := secret.Metadata.CurrentVersion
+					if v, exists := secret.Versions[cv]; exists {
+						if v.DeletedTime == nil {
+							t.Errorf("Current version should be marked as deleted")
+						}
+					}
+				} else {
+					for _, version := range tt.versions {
+						if version == 0 {
+							version = secret.Metadata.CurrentVersion
+						}
+						if v, exists := secret.Versions[version]; exists {
+							if v.DeletedTime == nil {
+								t.Errorf("Version %d should be marked as deleted", version)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/kv/doc.go
+++ b/kv/doc.go
@@ -1,0 +1,9 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+// Package kv provides a secure in-memory key-value store for managing secret
+// data. The store supports versioning of secrets, allowing operations on
+// specific versions and tracking deleted versions. It is designed for scenarios
+// where secrets need to be securely managed, updated, and deleted.
+package kv

--- a/kv/entity.go
+++ b/kv/entity.go
@@ -1,0 +1,56 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+import "time"
+
+// Version represents a single version of a secret's data along with its
+// metadata. Each version maintains its own set of key-value pairs and tracking
+// information.
+type Version struct {
+	// Data contains the actual key-value pairs stored in this version
+	Data map[string]string
+
+	// CreatedTime is when this version was created
+	CreatedTime time.Time
+
+	// Version is the numeric identifier for this version
+	Version int
+
+	// DeletedTime indicates when this version was marked as deleted
+	// A nil value means the version is active/not deleted
+	DeletedTime *time.Time
+}
+
+// Metadata tracks control information for a secret and its versions.
+// It maintains version boundaries and timestamps for the overall secret.
+type Metadata struct {
+	// CurrentVersion is the newest/latest version number of the secret
+	CurrentVersion int
+
+	// OldestVersion is the oldest available version number of the secret
+	OldestVersion int
+
+	// CreatedTime is when the secret was first created
+	CreatedTime time.Time
+
+	// UpdatedTime is when the secret was last modified
+	UpdatedTime time.Time
+
+	// MaxVersions is the maximum number of versions to retain
+	// When exceeded, older versions are automatically pruned
+	MaxVersions int
+}
+
+// Secret represents a versioned collection of key-value pairs stored at a
+// specific path. It maintains both the version history and metadata about the
+// collection as a whole.
+type Secret struct {
+	// Versions maps version numbers to their corresponding Version objects
+	Versions map[int]Version
+
+	// Metadata contains control information about this secret
+	Metadata Metadata
+}

--- a/kv/err.go
+++ b/kv/err.go
@@ -1,0 +1,14 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+import "errors"
+
+var (
+	ErrVersionNotFound = errors.New("version not found")
+	ErrItemNotFound    = errors.New("item not found")
+	ErrItemSoftDeleted = errors.New("item marked as deleted")
+	ErrInvalidVersion  = errors.New("invalid version")
+)

--- a/kv/get.go
+++ b/kv/get.go
@@ -1,0 +1,80 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+// Get retrieves a versioned key-value data map from the store at the specified
+// path.
+//
+// The function supports versioned data retrieval with the following behavior:
+//   - If version is 0, returns the current version of the data
+//   - If version is specified, returns that specific version if it exists
+//   - Returns nil and false if the path doesn't exist
+//   - Returns nil and false if the specified version doesn't exist
+//   - Returns nil and false if the version has been deleted
+//     (DeletedTime is set)
+//
+// Parameters:
+//   - path: The path to retrieve data from
+//   - version: The specific version to retrieve (0 for current version)
+//
+// Returns:
+//   - map[string]string: The key-value data at the specified path and version
+//   - bool: true if data was found and is valid, false otherwise
+//
+// Example usage:
+//
+//	kv := &KV{}
+//	// Get current version
+//	data, exists := kv.Get("secret/myapp", 0)
+//
+//	// Get specific version
+//	historicalData, exists := kv.Get("secret/myapp", 2)
+func (kv *KV) Get(path string, version int) (map[string]string, error) {
+	secret, exists := kv.data[path]
+	if !exists {
+		return nil, ErrItemNotFound
+	}
+
+	// #region debug
+	// fmt.Println("########")
+	// vv := secret.Versions
+	// for i, v := range vv {
+	// 	fmt.Println("version", i, "version:", v.Version, "created:",
+	// 		v.CreatedTime, "deleted:", v.DeletedTime, "data:", v.Data)
+	// }
+	// fmt.Println("########")
+	// #endregion
+
+	// If version not specified, use current version
+	if version == 0 {
+		version = secret.Metadata.CurrentVersion
+	}
+
+	v, exists := secret.Versions[version]
+	if !exists || v.DeletedTime != nil {
+		return nil, ErrItemSoftDeleted
+	}
+
+	return v.Data, nil
+}
+
+// GetRawSecret retrieves a raw secret from the store at the specified path.
+// This function is similar to Get, but it returns the raw Secret object instead
+// of the key-value data map.
+//
+// Parameters:
+// - path: The path to retrieve the secret from
+//
+// Returns:
+//   - *Secret: The secret at the specified path, or nil if it doesn't exist
+//     or has been deleted.
+func (kv *KV) GetRawSecret(path string) (*Secret, error) {
+	secret, exists := kv.data[path]
+	if !exists {
+		return nil, ErrItemNotFound
+	}
+
+	return secret, nil
+}

--- a/kv/get_test.go
+++ b/kv/get_test.go
@@ -1,0 +1,281 @@
+package kv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKV_Get(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() *KV
+		path    string
+		version int
+		want    map[string]string
+		wantErr error
+	}{
+		{
+			name: "non_existent_path",
+			setup: func() *KV {
+				return &KV{
+					data: make(map[string]*Secret),
+				}
+			},
+			path:    "non/existent/path",
+			version: 0,
+			want:    nil,
+			wantErr: ErrItemNotFound,
+		},
+		{
+			name: "get_current_version",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "current_value",
+							},
+							Version: 1,
+						},
+					},
+				}
+				return kv
+			},
+			path:    "test/path",
+			version: 0,
+			want: map[string]string{
+				"key": "current_value",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_specific_version",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 2,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "old_value",
+							},
+							Version: 1,
+						},
+						2: {
+							Data: map[string]string{
+								"key": "current_value",
+							},
+							Version: 2,
+						},
+					},
+				}
+				return kv
+			},
+			path:    "test/path",
+			version: 1,
+			want: map[string]string{
+				"key": "old_value",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "get_deleted_version",
+			setup: func() *KV {
+				deletedTime := time.Now()
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "deleted_value",
+							},
+							Version:     1,
+							DeletedTime: &deletedTime,
+						},
+					},
+				}
+				return kv
+			},
+			path:    "test/path",
+			version: 1,
+			want:    nil,
+			wantErr: ErrItemSoftDeleted,
+		},
+		{
+			name: "non_existent_version",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "value",
+							},
+							Version: 1,
+						},
+					},
+				}
+				return kv
+			},
+			path:    "test/path",
+			version: 999,
+			want:    nil,
+			wantErr: ErrItemSoftDeleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			got, err := kv.Get(tt.path, tt.version)
+
+			if err != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == nil {
+				if len(got) != len(tt.want) {
+					t.Errorf("Get() got = %v, want %v", got, tt.want)
+					return
+				}
+				for k, v := range got {
+					if tt.want[k] != v {
+						t.Errorf("Get() got[%s] = %v, want[%s] = %v", k, v, k, tt.want[k])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestKV_GetRawSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() *KV
+		path    string
+		want    *Secret
+		wantErr error
+	}{
+		{
+			name: "non_existent_path",
+			setup: func() *KV {
+				return &KV{
+					data: make(map[string]*Secret),
+				}
+			},
+			path:    "non/existent/path",
+			want:    nil,
+			wantErr: ErrItemNotFound,
+		},
+		{
+			name: "existing_secret",
+			setup: func() *KV {
+				secret := &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data: map[string]string{
+								"key": "value",
+							},
+							Version: 1,
+						},
+					},
+				}
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = secret
+				return kv
+			},
+			path: "test/path",
+			want: &Secret{
+				Metadata: Metadata{
+					CurrentVersion: 1,
+				},
+				Versions: map[int]Version{
+					1: {
+						Data: map[string]string{
+							"key": "value",
+						},
+						Version: 1,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			got, err := kv.GetRawSecret(tt.path)
+
+			if err != tt.wantErr {
+				t.Errorf("GetRawSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr == nil {
+				if got.Metadata.CurrentVersion != tt.want.Metadata.CurrentVersion {
+					t.Errorf("GetRawSecret() got CurrentVersion = %v, want %v",
+						got.Metadata.CurrentVersion, tt.want.Metadata.CurrentVersion)
+				}
+
+				if len(got.Versions) != len(tt.want.Versions) {
+					t.Errorf("GetRawSecret() got Versions length = %v, want %v",
+						len(got.Versions), len(tt.want.Versions))
+					return
+				}
+
+				for version, gotV := range got.Versions {
+					wantV, exists := tt.want.Versions[version]
+					if !exists {
+						t.Errorf("GetRawSecret() unexpected version %v in result", version)
+						continue
+					}
+
+					if gotV.Version != wantV.Version {
+						t.Errorf("GetRawSecret() version %v: got Version = %v, want %v",
+							version, gotV.Version, wantV.Version)
+					}
+
+					if len(gotV.Data) != len(wantV.Data) {
+						t.Errorf("GetRawSecret() version %v: got Data length = %v, want %v",
+							version, len(gotV.Data), len(wantV.Data))
+						continue
+					}
+
+					for k, v := range gotV.Data {
+						if wantV.Data[k] != v {
+							t.Errorf("GetRawSecret() version %v: got Data[%s] = %v, want %v",
+								version, k, v, wantV.Data[k])
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -1,0 +1,24 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+// KV represents an in-memory key-value store with versioning
+type KV struct {
+	maxSecretVersions int
+	data              map[string]*Secret
+}
+
+// KVConfig represents the configuration for a KV instance
+type KVConfig struct {
+	MaxSecretVersions int
+}
+
+// NewKV creates a new KV instance
+func NewKV(config KVConfig) *KV {
+	return &KV{
+		maxSecretVersions: config.MaxSecretVersions,
+		data:              make(map[string]*Secret),
+	}
+}

--- a/kv/list.go
+++ b/kv/list.go
@@ -1,0 +1,21 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+// List returns a slice containing all keys stored in the key-value store.
+// The order of keys in the returned slice is not guaranteed to be stable
+// between calls.
+//
+// Returns:
+//   - []string: A slice containing all keys present in the store
+func (kv *KV) List() []string {
+	keys := make([]string, 0, len(kv.data))
+
+	for k := range kv.data {
+		keys = append(keys, k)
+	}
+
+	return keys
+}

--- a/kv/list_test.go
+++ b/kv/list_test.go
@@ -1,0 +1,61 @@
+package kv
+
+import "testing"
+
+func TestKV_List(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func() *KV
+		want  []string
+	}{
+		{
+			name: "empty_store",
+			setup: func() *KV {
+				return &KV{
+					data: make(map[string]*Secret),
+				}
+			},
+			want: []string{},
+		},
+		{
+			name: "non_empty_store",
+			setup: func() *KV {
+				return &KV{
+					data: map[string]*Secret{
+						"test/path": {
+							Metadata: Metadata{
+								CurrentVersion: 1,
+							},
+							Versions: map[int]Version{
+								1: {
+									Data: map[string]string{
+										"key": "value",
+									},
+									Version: 1,
+								},
+							},
+						},
+					},
+				}
+			},
+			want: []string{"test/path"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			got := kv.List()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("got %v want %v", got, tt.want)
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got %v want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/kv/put.go
+++ b/kv/put.go
@@ -1,0 +1,85 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+import (
+	"time"
+)
+
+// Put stores a new version of key-value pairs at the specified path in the
+// store. It implements automatic versioning with a maximum of 3 versions per
+// path.
+//
+// When storing values:
+//   - If the path doesn't exist, it creates a new secret with initial metadata
+//   - Each put operation creates a new version with an incremented version
+//     number
+//   - Old versions are automatically pruned when exceeding MaxVersions
+//     (default: 10)
+//   - Timestamps are updated for both creation and modification times
+//
+// Parameters:
+//   - path: The location where the secret will be stored
+//   - values: A map of key-value pairs to store at this path
+//
+// The function maintains metadata including:
+//   - CreatedTime: When the secret was first created
+//   - UpdatedTime: When the most recent version was added
+//   - CurrentVersion: The latest version number
+//   - OldestVersion: The oldest available version number
+//   - MaxVersions: Maximum number of versions to keep (fixed at 10)
+func (kv *KV) Put(path string, values map[string]string) {
+	rightNow := time.Now()
+
+	secret, exists := kv.data[path]
+	if !exists {
+		secret = &Secret{
+			Versions: make(map[int]Version),
+			Metadata: Metadata{
+				CreatedTime: rightNow,
+				UpdatedTime: rightNow,
+				MaxVersions: kv.maxSecretVersions,
+				// Versions start at 1, so that passing 0 as version will
+				// default to the current version.
+				CurrentVersion: 1,
+				OldestVersion:  1,
+			},
+		}
+		kv.data[path] = secret
+	} else {
+		secret.Metadata.CurrentVersion++
+	}
+
+	newVersion := secret.Metadata.CurrentVersion
+
+	// Add new version
+	secret.Versions[newVersion] = Version{
+		Data:        values,
+		CreatedTime: rightNow,
+		Version:     newVersion,
+	}
+
+	// Update metadata
+	secret.Metadata.UpdatedTime = rightNow
+
+	// Cleanup old versions if exceeding MaxVersions
+	var deletedAny bool
+	for version := range secret.Versions {
+		if newVersion-version >= secret.Metadata.MaxVersions {
+			delete(secret.Versions, version)
+			deletedAny = true
+		}
+	}
+
+	if deletedAny {
+		oldestVersion := secret.Metadata.CurrentVersion
+		for version := range secret.Versions {
+			if version < oldestVersion {
+				oldestVersion = version
+			}
+		}
+		secret.Metadata.OldestVersion = oldestVersion
+	}
+}

--- a/kv/put_test.go
+++ b/kv/put_test.go
@@ -1,0 +1,94 @@
+package kv
+
+import (
+	"testing"
+)
+
+func TestKV_Put(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *KV
+		path     string
+		values   map[string]string
+		versions []int
+		wantErr  error
+	}{
+		{
+			setup: func() *KV {
+				return &KV{
+					data:              make(map[string]*Secret),
+					maxSecretVersions: 10,
+				}
+			},
+			name:     "it creates a new secret with initial metadata if the path doesn't exist",
+			path:     "new/secret/path",
+			versions: []int{1},
+			values:   map[string]string{"key": "value"},
+			wantErr:  nil,
+		},
+		{
+			name: "it creates a new version with an incremented version number",
+			setup: func() *KV {
+				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 10}
+				kv.Put("existing/secret/path", map[string]string{"key": "value1"})
+				return kv
+			},
+			path:     "existing/secret/path",
+			versions: []int{1, 2},
+			wantErr:  nil,
+		},
+		{
+			name: "it automatically prunes old versions when exceeding MaxVersions",
+			setup: func() *KV {
+				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 2}
+				kv.Put("prune/old/versions", map[string]string{"key": "value1"})
+				kv.Put("prune/old/versions", map[string]string{"key": "value2"})
+				kv.Put("prune/old/versions", map[string]string{"key": "value3"})
+				return kv
+			},
+			path:     "prune/old/versions",
+			versions: []int{4, 3},
+			values: map[string]string{
+				"key": "value4",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "it updates timestamps for both creation and modification times",
+			setup: func() *KV {
+				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 10}
+				kv.Put("update/timestamps", map[string]string{"key": "value1"})
+				return kv
+			},
+			versions: []int{1, 2},
+			path:     "update/timestamps",
+			values:   map[string]string{"key": "value2"},
+			wantErr:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			kv.Put(tt.path, tt.values)
+
+			secret, exists := kv.data[tt.path]
+			if !exists {
+				t.Fatalf("expected secret to exist at path %q", tt.path)
+			}
+
+			if len(secret.Versions) != len(tt.versions) {
+				t.Fatalf("expected %d versions, got %d", len(tt.versions), len(secret.Versions))
+			}
+
+			for _, version := range tt.versions {
+				if _, exists := secret.Versions[version]; !exists {
+					t.Fatalf("expected version %d to exist", version)
+				}
+			}
+
+			if tt.wantErr != nil {
+				t.Fatalf("unexpected error: %v", tt.wantErr)
+			}
+		})
+	}
+}

--- a/kv/undelete.go
+++ b/kv/undelete.go
@@ -1,0 +1,57 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package kv
+
+// Undelete restores previously deleted versions of a secret at the specified
+// path. It sets the DeletedTime to nil for each specified version that exists.
+//
+// Parameters:
+//   - path: The location of the secret in the store
+//   - versions: A slice of version numbers to undelete
+//
+// Returns:
+//   - error: ErrItemNotFound if the path doesn't exist, nil on success
+//
+// If a version number in the versions slice doesn't exist, it is silently
+// skipped without returning an error. Only existing versions are modified.
+func (kv *KV) Undelete(path string, versions []int) error {
+	secret, exists := kv.data[path]
+	if !exists {
+		return ErrItemNotFound
+	}
+
+	cv := secret.Metadata.CurrentVersion
+
+	// If no versions specified, mark the latest version as undeleted
+	if len(versions) == 0 {
+		if v, exists := secret.Versions[cv]; exists {
+			v.DeletedTime = nil // Mark as undeleted.
+			secret.Versions[cv] = v
+		}
+
+		return nil
+	}
+
+	// Delete specific versions
+	for _, version := range versions {
+		if version == 0 {
+			v, exists := secret.Versions[cv]
+			if !exists {
+				continue
+			}
+
+			v.DeletedTime = nil // Mark as undeleted.
+			secret.Versions[cv] = v
+			continue
+		}
+
+		if v, exists := secret.Versions[version]; exists {
+			v.DeletedTime = nil // Mark as undeleted.
+			secret.Versions[version] = v
+		}
+	}
+
+	return nil
+}

--- a/kv/undelete_test.go
+++ b/kv/undelete_test.go
@@ -1,0 +1,182 @@
+package kv
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestKV_Undelete(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *KV
+		path     string
+		values   map[string]string
+		versions []int
+		wantErr  error
+	}{
+		{
+			name: "undelete latest version if no versions specified",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data:        map[string]string{"key": "value"},
+							Version:     1,
+							DeletedTime: &time.Time{},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: []int{},
+			wantErr:  nil,
+		},
+		{
+			name: "undelete spesific versions",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 2,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data:        map[string]string{"key": "value1"},
+							Version:     1,
+							DeletedTime: &time.Time{},
+						},
+						2: {
+							Data:        map[string]string{"key": "value2"},
+							Version:     2,
+							DeletedTime: &time.Time{},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: []int{1, 2},
+			wantErr:  nil,
+		},
+		{
+			name: "if secret does not exist",
+			setup: func() *KV {
+				return &KV{
+					data:              make(map[string]*Secret),
+					maxSecretVersions: 10,
+				}
+			},
+			path:     "path/undelete/notExist",
+			versions: []int{1},
+			values:   map[string]string{"key": "value"},
+			wantErr:  ErrItemNotFound,
+		},
+		{
+			name: "skip non-existent versions",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data:        map[string]string{"key": "value"},
+							Version:     1,
+							DeletedTime: &time.Time{},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: []int{1, 2},
+			wantErr:  nil,
+		},
+		{
+			name: "skip non-existent versions",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 2,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data:        map[string]string{"key": "value"},
+							Version:     1,
+							DeletedTime: &time.Time{},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			versions: []int{0},
+			wantErr:  nil,
+		},
+		{
+			name: "if version is 0 undelete current version",
+			setup: func() *KV {
+				kv := &KV{
+					data: make(map[string]*Secret),
+				}
+				kv.data["test/path"] = &Secret{
+					Metadata: Metadata{
+						CurrentVersion: 1,
+					},
+					Versions: map[int]Version{
+						1: {
+							Data:        map[string]string{"key": "value"},
+							Version:     1,
+							DeletedTime: &time.Time{},
+						},
+					},
+				}
+				return kv
+			},
+			path:     "test/path",
+			values:   map[string]string{"key": "value"},
+			versions: []int{0},
+			wantErr:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := tt.setup()
+			err := kv.Undelete(tt.path, tt.versions)
+			assert.Equal(t, tt.wantErr, err)
+
+			if err == nil {
+				secret, exist := kv.data[tt.path]
+				assert.True(t, exist)
+
+				for _, version := range tt.versions {
+					if version == 0 {
+						version = secret.Metadata.CurrentVersion
+					}
+					if v, exist := secret.Versions[version]; exist {
+						assert.True(t, exist)
+						assert.Nil(t, v.DeletedTime)
+					}
+
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moved the in-memory key-value store out of tree into the SDK.

The module appears like a general-purpose key-value store, so it can benefit others, too. As part of this SDK, consumers can use the store without necessarily having to use the rest of SPIKE.

In addition, this will provide transparency about how secrets are stored in memory, and will enable creating isolated test suites independent of the SPIKE core itself.

Also, those who want to integrate with SPIKE, or want to use a similar backing store (maybe as a backup medium, or caching purposes) will be able to use the very same implementation that SPIKE uses internally eliminating possible compatibility concerns.

In addition, if the key-value store is used for external purposes by the community, it will mean additional hardening and battle-testing and potential to recover edge cases and performance improvements that we might have overlooked.

Overall, it feels like a good idea.