### PR TITLE
Make kv value more generic

### DIFF
--- a/kv/delete_test.go
+++ b/kv/delete_test.go
@@ -16,7 +16,7 @@ func TestKV_Delete(t *testing.T) {
 			name: "non_existent_path",
 			setup: func() *KV {
 				return &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
 			},
 			path:     "non/existent/path",
@@ -27,9 +27,9 @@ func TestKV_Delete(t *testing.T) {
 			name: "delete_current_version_no_versions_specified",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -51,9 +51,9 @@ func TestKV_Delete(t *testing.T) {
 			name: "delete_specific_versions",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 2,
 					},
@@ -91,7 +91,7 @@ func TestKV_Delete(t *testing.T) {
 			if tt.wantErr == nil {
 				secret, exists := kv.data[tt.path]
 				if !exists {
-					t.Errorf("Secret should still exist after deletion")
+					t.Errorf("Value should still exist after deletion")
 					return
 				}
 

--- a/kv/entity.go
+++ b/kv/entity.go
@@ -44,10 +44,10 @@ type Metadata struct {
 	MaxVersions int
 }
 
-// Secret represents a versioned collection of key-value pairs stored at a
+// Value represents a versioned collection of key-value pairs stored at a
 // specific path. It maintains both the version history and metadata about the
 // collection as a whole.
-type Secret struct {
+type Value struct {
 	// Versions maps version numbers to their corresponding Version objects
 	Versions map[int]Version
 

--- a/kv/get.go
+++ b/kv/get.go
@@ -61,16 +61,16 @@ func (kv *KV) Get(path string, version int) (map[string]string, error) {
 }
 
 // GetRawSecret retrieves a raw secret from the store at the specified path.
-// This function is similar to Get, but it returns the raw Secret object instead
+// This function is similar to Get, but it returns the raw Value object instead
 // of the key-value data map.
 //
 // Parameters:
 // - path: The path to retrieve the secret from
 //
 // Returns:
-//   - *Secret: The secret at the specified path, or nil if it doesn't exist
+//   - *Value: The secret at the specified path, or nil if it doesn't exist
 //     or has been deleted.
-func (kv *KV) GetRawSecret(path string) (*Secret, error) {
+func (kv *KV) GetRawSecret(path string) (*Value, error) {
 	secret, exists := kv.data[path]
 	if !exists {
 		return nil, ErrItemNotFound

--- a/kv/get_test.go
+++ b/kv/get_test.go
@@ -18,7 +18,7 @@ func TestKV_Get(t *testing.T) {
 			name: "non_existent_path",
 			setup: func() *KV {
 				return &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
 			},
 			path:    "non/existent/path",
@@ -30,9 +30,9 @@ func TestKV_Get(t *testing.T) {
 			name: "get_current_version",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -58,9 +58,9 @@ func TestKV_Get(t *testing.T) {
 			name: "get_specific_version",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 2,
 					},
@@ -93,9 +93,9 @@ func TestKV_Get(t *testing.T) {
 			setup: func() *KV {
 				deletedTime := time.Now()
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -120,9 +120,9 @@ func TestKV_Get(t *testing.T) {
 			name: "non_existent_version",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -174,14 +174,14 @@ func TestKV_GetRawSecret(t *testing.T) {
 		name    string
 		setup   func() *KV
 		path    string
-		want    *Secret
+		want    *Value
 		wantErr error
 	}{
 		{
 			name: "non_existent_path",
 			setup: func() *KV {
 				return &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
 			},
 			path:    "non/existent/path",
@@ -191,7 +191,7 @@ func TestKV_GetRawSecret(t *testing.T) {
 		{
 			name: "existing_secret",
 			setup: func() *KV {
-				secret := &Secret{
+				secret := &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -205,13 +205,13 @@ func TestKV_GetRawSecret(t *testing.T) {
 					},
 				}
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
 				kv.data["test/path"] = secret
 				return kv
 			},
 			path: "test/path",
-			want: &Secret{
+			want: &Value{
 				Metadata: Metadata{
 					CurrentVersion: 1,
 				},

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -7,7 +7,7 @@ package kv
 // KV represents an in-memory key-value store with versioning
 type KV struct {
 	maxSecretVersions int
-	data              map[string]*Secret
+	data              map[string]*Value
 }
 
 // KVConfig represents the configuration for a KV instance
@@ -19,6 +19,6 @@ type KVConfig struct {
 func NewKV(config KVConfig) *KV {
 	return &KV{
 		maxSecretVersions: config.MaxSecretVersions,
-		data:              make(map[string]*Secret),
+		data:              make(map[string]*Value),
 	}
 }

--- a/kv/list_test.go
+++ b/kv/list_test.go
@@ -12,7 +12,7 @@ func TestKV_List(t *testing.T) {
 			name: "empty_store",
 			setup: func() *KV {
 				return &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
 			},
 			want: []string{},
@@ -21,7 +21,7 @@ func TestKV_List(t *testing.T) {
 			name: "non_empty_store",
 			setup: func() *KV {
 				return &KV{
-					data: map[string]*Secret{
+					data: map[string]*Value{
 						"test/path": {
 							Metadata: Metadata{
 								CurrentVersion: 1,

--- a/kv/put.go
+++ b/kv/put.go
@@ -35,7 +35,7 @@ func (kv *KV) Put(path string, values map[string]string) {
 
 	secret, exists := kv.data[path]
 	if !exists {
-		secret = &Secret{
+		secret = &Value{
 			Versions: make(map[int]Version),
 			Metadata: Metadata{
 				CreatedTime: rightNow,

--- a/kv/put_test.go
+++ b/kv/put_test.go
@@ -16,7 +16,7 @@ func TestKV_Put(t *testing.T) {
 		{
 			setup: func() *KV {
 				return &KV{
-					data:              make(map[string]*Secret),
+					data:              make(map[string]*Value),
 					maxSecretVersions: 10,
 				}
 			},
@@ -29,7 +29,7 @@ func TestKV_Put(t *testing.T) {
 		{
 			name: "it creates a new version with an incremented version number",
 			setup: func() *KV {
-				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 10}
+				kv := &KV{data: make(map[string]*Value), maxSecretVersions: 10}
 				kv.Put("existing/secret/path", map[string]string{"key": "value1"})
 				return kv
 			},
@@ -40,7 +40,7 @@ func TestKV_Put(t *testing.T) {
 		{
 			name: "it automatically prunes old versions when exceeding MaxVersions",
 			setup: func() *KV {
-				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 2}
+				kv := &KV{data: make(map[string]*Value), maxSecretVersions: 2}
 				kv.Put("prune/old/versions", map[string]string{"key": "value1"})
 				kv.Put("prune/old/versions", map[string]string{"key": "value2"})
 				kv.Put("prune/old/versions", map[string]string{"key": "value3"})
@@ -56,7 +56,7 @@ func TestKV_Put(t *testing.T) {
 		{
 			name: "it updates timestamps for both creation and modification times",
 			setup: func() *KV {
-				kv := &KV{data: make(map[string]*Secret), maxSecretVersions: 10}
+				kv := &KV{data: make(map[string]*Value), maxSecretVersions: 10}
 				kv.Put("update/timestamps", map[string]string{"key": "value1"})
 				return kv
 			},

--- a/kv/undelete_test.go
+++ b/kv/undelete_test.go
@@ -19,9 +19,9 @@ func TestKV_Undelete(t *testing.T) {
 			name: "undelete latest version if no versions specified",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -43,9 +43,9 @@ func TestKV_Undelete(t *testing.T) {
 			name: "undelete spesific versions",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 2,
 					},
@@ -72,7 +72,7 @@ func TestKV_Undelete(t *testing.T) {
 			name: "if secret does not exist",
 			setup: func() *KV {
 				return &KV{
-					data:              make(map[string]*Secret),
+					data:              make(map[string]*Value),
 					maxSecretVersions: 10,
 				}
 			},
@@ -85,9 +85,9 @@ func TestKV_Undelete(t *testing.T) {
 			name: "skip non-existent versions",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},
@@ -109,9 +109,9 @@ func TestKV_Undelete(t *testing.T) {
 			name: "skip non-existent versions",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 2,
 					},
@@ -133,9 +133,9 @@ func TestKV_Undelete(t *testing.T) {
 			name: "if version is 0 undelete current version",
 			setup: func() *KV {
 				kv := &KV{
-					data: make(map[string]*Secret),
+					data: make(map[string]*Value),
 				}
-				kv.data["test/path"] = &Secret{
+				kv.data["test/path"] = &Value{
 					Metadata: Metadata{
 						CurrentVersion: 1,
 					},


### PR DESCRIPTION
the entity was named `Secret`, renamed it to
`Value` as `Secret` was leaking business logic.