### PR TITLE
Add memory locking.

### DIFF
--- a/hack/tag.sh
+++ b/hack/tag.sh
@@ -4,7 +4,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-VERSION="v0.5.5"
+VERSION="v0.5.6"
 
 git tag -s "$VERSION" -m "$VERSION"
 git push oigin --tags

--- a/security/mem/secure.go
+++ b/security/mem/secure.go
@@ -8,6 +8,7 @@ package mem
 import (
 	"crypto/rand"
 	"runtime"
+	"syscall"
 	"unsafe"
 )
 
@@ -175,4 +176,20 @@ func ClearBytes(b []byte) {
 
 	// Make sure the data is actually wiped before gc has time to interfere
 	runtime.KeepAlive(b)
+}
+
+// Lock attempts to lock the process memory to prevent swapping.
+// Returns true if successful, false if not supported or failed.
+func Lock() bool {
+	// `mlock` is only available on Unix-like systems
+	if runtime.GOOS == "windows" {
+		return false
+	}
+
+	// Attempt to lock all current and future memory
+	if err := syscall.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE); err != nil {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Adds `mlock` to a helper methods.

It tries to lock memory and returns true if it can; return false without an error if it cannot.