### PR TITLE
Enhance HTTP client configuration with timeout and connection settings

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
@@ -112,7 +114,19 @@ func CreateMtlsClientWithPredicate(
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
+			IdleConnTimeout: 30 * time.Second,
+			MaxIdleConns: 100,
+			MaxConnsPerHost: 10,
+			MaxIdleConnsPerHost: 10,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			ExpectContinueTimeout: 5 * time.Second,
 		},
+		Timeout: 60 * time.Second,
 	}
 
 	return client, nil


### PR DESCRIPTION
There was a goroutine leak caused by incorrect http.Transport configuration. When sending secrets to keepers with the client, connections weren't being properly closed. These configuration changes fix the leak.






This pull request includes changes to the `net/net.go` file to enhance the configuration of the HTTP client used for mTLS connections. The most important changes involve importing additional packages and configuring various timeouts and connection limits for the HTTP client.

Changes to HTTP client configuration:

* [`net/net.go`](diffhunk://#diff-85b6d38e7e77f99d0018695343944555050e58f3b190ffa74041fdd702e4c30aR11-R13): Imported the `net` and `time` packages to support new configurations.
* [`net/net.go`](diffhunk://#diff-85b6d38e7e77f99d0018695343944555050e58f3b190ffa74041fdd702e4c30aR117-R129): Added configurations for `IdleConnTimeout`, `MaxIdleConns`, `MaxConnsPerHost`, `MaxIdleConnsPerHost`, `DialContext`, `TLSHandshakeTimeout`, `ResponseHeaderTimeout`, `ExpectContinueTimeout`, and overall client `Timeout` in the `CreateMtlsClientWithPredicate` function.