### PR TITLE
Add trustRoot as an argument for flexibility.

### DIFF
--- a/hack/tag.sh
+++ b/hack/tag.sh
@@ -4,7 +4,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-VERSION="v0.5.7"
+VERSION="v0.5.10"
 
 git tag -s "$VERSION" -m "$VERSION"
 git push origin --tags

--- a/spiffeid/auth.go
+++ b/spiffeid/auth.go
@@ -11,6 +11,7 @@ package spiffeid
 // the expected pilot SPIFFE ID returned by SpikePilotSpiffeId().
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - spiffeid: The SPIFFE ID string to check
 //
 // Returns:
@@ -20,11 +21,11 @@ package spiffeid
 // Example usage:
 //
 //	id := "spiffe://example.org/spike/pilot"
-//	if IsPilot(id) {
+//	if IsPilot("example.org", id) {
 //	    // Handle pilot-specific logic
 //	}
-func IsPilot(id string) bool {
-	return id == SpikePilot()
+func IsPilot(trustRoot, id string) bool {
+	return id == SpikePilot(trustRoot)
 }
 
 // IsPilotRecover checks if a given SPIFFE ID matches the SPIKE Pilot's
@@ -35,6 +36,7 @@ func IsPilot(id string) bool {
 // recovery SPIFFE ID returned by SpikePilotRecoverSpiffeId().
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - spiffeId: The SPIFFE ID string to check
 //
 // Returns:
@@ -44,11 +46,11 @@ func IsPilot(id string) bool {
 // Example usage:
 //
 //	id := "spiffe://example.org/spike/pilot/recover"
-//	if IsPilotRecover(id) {
+//	if IsPilotRecover("example.org", id) {
 //	    // Handle recovery-specific logic
 //	}
-func IsPilotRecover(id string) bool {
-	return id == SpikePilotRecover()
+func IsPilotRecover(trustRoot, id string) bool {
+	return id == SpikePilotRecover(trustRoot)
 }
 
 // IsPilotRestore checks if a given SPIFFE ID matches the SPIKE Pilot's restore
@@ -59,6 +61,7 @@ func IsPilotRecover(id string) bool {
 // restore SPIFFE ID returned by SpikePilotRestoreSpiffeId().
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - spiffeId: The SPIFFE ID string to check
 //
 // Returns:
@@ -68,11 +71,11 @@ func IsPilotRecover(id string) bool {
 // Example usage:
 //
 //	id := "spiffe://example.org/spike/pilot/restore"
-//	if IsPilotRestore(id) {
+//	if IsPilotRestore("example.org", id) {
 //	    // Handle restore-specific logic
 //	}
-func IsPilotRestore(spiffeId string) bool {
-	return spiffeId == SpikePilotRestore()
+func IsPilotRestore(trustRoot, spiffeId string) bool {
+	return spiffeId == SpikePilotRestore(trustRoot)
 }
 
 // IsKeeper checks if a given SPIFFE ID matches the SPIKE Keeper's SPIFFE ID.
@@ -82,6 +85,7 @@ func IsPilotRestore(spiffeId string) bool {
 // the expected pilot SPIFFE ID returned by SpikeKeeperSpiffeId().
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - spiffeid: The SPIFFE ID string to check
 //
 // Returns:
@@ -91,11 +95,11 @@ func IsPilotRestore(spiffeId string) bool {
 // Example usage:
 //
 //	id := "spiffe://example.org/spike/keeper"
-//	if IsKeeper(id) {
+//	if IsKeeper("example.org", id) {
 //	    // Handle pilot-specific logic
 //	}
-func IsKeeper(id string) bool {
-	return id == SpikeKeeper()
+func IsKeeper(trustRoot, id string) bool {
+	return id == SpikeKeeper(trustRoot)
 }
 
 // IsNexus checks if the provided SPIFFE ID matches the SPIKE Nexus SPIFFE ID.
@@ -105,16 +109,17 @@ func IsKeeper(id string) bool {
 // a given identity represents the Nexus service.
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - spiffeid: The SPIFFE ID string to check
 //
 // Returns:
 //   - bool: true if the SPIFFE ID matches the Nexus SPIFFE ID, false otherwise
-func IsNexus(id string) bool {
-	return id == SpikeNexus()
+func IsNexus(trustRoot, id string) bool {
+	return id == SpikeNexus(trustRoot)
 }
 
 // PeerCanTalkToAnyone is used for debugging purposes
-func PeerCanTalkToAnyone(_ string) bool {
+func PeerCanTalkToAnyone(_, _ string) bool {
 	return true
 }
 
@@ -125,11 +130,12 @@ func PeerCanTalkToAnyone(_ string) bool {
 // Nexus can talk to SPIKE Keeper.
 //
 // Parameters:
+//   - trustRoot: The trust domain root (e.g., "example.org")
 //   - peerSpiffeId: The SPIFFE ID string to check
 //
 // Returns:
 //   - bool: true if the SPIFFE ID matches SPIKE Nexus' SPIFFE ID,
 //     false otherwise
-func PeerCanTalkToKeeper(peerSpiffeId string) bool {
-	return peerSpiffeId == SpikeNexus()
+func PeerCanTalkToKeeper(trustRoot, peerSpiffeId string) bool {
+	return peerSpiffeId == SpikeNexus(trustRoot)
 }

--- a/spiffeid/spiffeid.go
+++ b/spiffeid/spiffeid.go
@@ -4,35 +4,93 @@
 
 package spiffeid
 
-import "github.com/spiffe/spike-sdk-go/spiffeid/internal/env"
+import (
+	"path"
 
-// SpikeKeeper constructs and returns the SPIKE Keeper's
-// SPIFFE ID string.
-// The output is constructed based on the trust root from the environment.
-func SpikeKeeper() string {
-	return "spiffe://" + env.TrustRoot() + "/spike/keeper"
+	"github.com/spiffe/spike-sdk-go/spiffeid/internal/env"
+)
+
+// SpikeKeeper constructs and returns the SPIKE Keeper's SPIFFE ID string.
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment.
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/keeper"
+func SpikeKeeper(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "keeper")
 }
 
 // SpikeNexus constructs and returns the SPIFFE ID for SPIKE Nexus.
-// The output is constructed based on the trust root from the environment.
-func SpikeNexus() string {
-	return "spiffe://" + env.TrustRoot() + "/spike/nexus"
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment.
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/nexus"
+func SpikeNexus(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "nexus")
 }
 
 // SpikePilot generates the SPIFFE ID for a SPIKE Pilot superuser role.
-// The output is constructed based on the trust root from the environment.
-func SpikePilot() string {
-	return "spiffe://" + env.TrustRoot() + "/spike/pilot/role/superuser"
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment.
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/pilot/role/superuser"
+func SpikePilot(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "pilot", "role", "superuser")
 }
 
 // SpikePilotRecover generates the SPIFFE ID for a SPIKE Pilot recovery role.
-// The output is constructed based on the trust root from the environment.
-func SpikePilotRecover() string {
-	return "spiffe://" + env.TrustRoot() + "/spike/pilot/role/recover"
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment.
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/pilot/role/recover"
+func SpikePilotRecover(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "pilot", "role", "recover")
 }
 
 // SpikePilotRestore generates the SPIFFE ID for a SPIKE Pilot restore role.
-// The output is constructed based on the trust root from the environment.
-func SpikePilotRestore() string {
-	return "spiffe://" + env.TrustRoot() + "/spike/pilot/role/restore"
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment.
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/pilot/role/restore"
+func SpikePilotRestore(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "pilot", "role", "restore")
 }


### PR DESCRIPTION
The validators may need to assume different trust roots, for federated/meshed setups where various components and workloads may reside in different trust boundaries.