### PR TITLE
fix: Add Windows build constraints for secure memory operations

### DIFF
--- a/security/mem/secure_windows.go
+++ b/security/mem/secure_windows.go
@@ -2,8 +2,8 @@
 //  \\\\\ Copyright 2024-present SPIKE contributors.
 // \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 // Package mem provides utilities for secure mem operations.
 package mem
@@ -11,7 +11,6 @@ package mem
 import (
 	"crypto/rand"
 	"runtime"
-	"syscall"
 	"unsafe"
 )
 
@@ -183,10 +182,6 @@ func ClearBytes(b []byte) {
 // Lock attempts to lock the process memory to prevent swapping.
 // Returns true if successful, false if not supported or failed.
 func Lock() bool {
-	// Attempt to lock all current and future memory
-	if err := syscall.Mlockall(syscall.MCL_CURRENT | syscall.MCL_FUTURE); err != nil {
-		return false
-	}
-
-	return true
+	// `mlock` is only available on Unix-like systems
+	return false
 }


### PR DESCRIPTION
- Create `security/mem/secure_windows.go` with windows build constraint to write windows specific operations.
- Return 'false' for mem.Lock() function in windows systems.
- Remove unreachable return statements after panic

## Fixes

- https://github.com/spiffe/spike/issues/147

### Tests

> **`go test ./security/...`**

```shell
# github.com/spiffe/spike-sdk-go/security/mem [github.com/spiffe/spike-sdk-go/security/mem.test]
security/mem/secure_test.go:31:2: undefined: Clear
FAIL    github.com/spiffe/spike-sdk-go/security/mem [build failed]
FAIL
```