### PR TITLE
feat(lock): add lock/unlock role check and SPIFFE ID generation

### DIFF
--- a/spiffeid/auth.go
+++ b/spiffeid/auth.go
@@ -209,6 +209,27 @@ func IsPilotRestore(trustRoots, id string) bool {
 	return false
 }
 
+// IsPilotLock checks whether the provided SPIFFE ID corresponds to the
+// Pilot lock/unlock role.
+//
+// Parameters:
+//   - trustRoots: A comma-separated list of trust domains.
+//   - id: The SPIFFE ID to validate.
+//
+// Returns:
+//   - bool: true if the id matches the lock role under any of the trust roots.
+func IsPilotLock(trustRoots, id string) bool {
+	for _, root := range strings.Split(trustRoots, ",") {
+		baseId := SpikePilotLock(strings.TrimSpace(root))
+		// Check if the ID is either exactly the base ID or starts with the base ID
+		// followed by "/"
+		if id == baseId || strings.HasPrefix(id, baseId+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // IsKeeper checks if a given SPIFFE ID matches the SPIKE Keeper's SPIFFE ID.
 //
 // This function is used for identity verification to determine if the provided

--- a/spiffeid/spiffeid.go
+++ b/spiffeid/spiffeid.go
@@ -111,3 +111,23 @@ func SpikePilotRestore(trustRoot string) string {
 
 	return "spiffe://" + path.Join(trustRoot, "spike", "pilot", "role", "restore")
 }
+
+// SpikePilotLock generates the SPIFFE ID for a SPIKE Pilot lock/unlock role.
+//
+// This role is used to perform critical operations such as locking or unlocking
+// the SPIKE system, typically requiring operator privileges.
+//
+// Parameters:
+//   - trustRoot: The trust domain for the SPIFFE ID. If empty, the value is
+//     obtained from the environment (via env.TrustRoot()).
+//
+// Returns:
+//   - string: The complete SPIFFE ID in the format:
+//     "spiffe://<trustRoot>/spike/pilot/role/watchdog"
+func SpikePilotLock(trustRoot string) string {
+	if trustRoot == "" {
+		trustRoot = env.TrustRoot()
+	}
+
+	return "spiffe://" + path.Join(trustRoot, "spike", "pilot", "role", "watchdog")
+}


### PR DESCRIPTION
Changes include:

- Added SpikePilotLock function to generate the SPIFFE ID for the lock/unlock role under a given trust domain.
This SPIFFE ID represents the role responsible for critical operations like locking and unlocking the SPIKE system, typically tied to operator privileges.

- Added IsPilotLock function to verify whether a given SPIFFE ID matches the lock/unlock role under one or more trust domains.
This enables the system to identify if a SPIFFE ID corresponds to an authorized lock/unlock operator.

Both functions follow the SPIFFE ID pattern conventions established in the spike-sdk and integrate with existing role checks.