### PR TITLE
chore: linting the code using golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 1m
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - gocyclo
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unused
+    - whitespace

--- a/api/internal/impl/api/secret/put.go
+++ b/api/internal/impl/api/secret/put.go
@@ -33,7 +33,6 @@ import (
 //	 	map[string]string{"key": "value"})
 func Put(source *workloadapi.X509Source,
 	path string, values map[string]string) error {
-
 	r := reqres.SecretPutRequest{
 		Path:   path,
 		Values: values,

--- a/kv/delete.go
+++ b/kv/delete.go
@@ -24,7 +24,6 @@ func (kv *KV) Delete(path string, versions []int) error {
 
 	// If no versions specified, mark the latest version as deleted
 	if len(versions) == 0 {
-
 		if v, exists := secret.Versions[cv]; exists {
 			v.DeletedTime = &now // Mark as deleted.
 			secret.Versions[cv] = v

--- a/kv/undelete_test.go
+++ b/kv/undelete_test.go
@@ -179,7 +179,6 @@ func TestKV_Undelete(t *testing.T) {
 						assert.True(t, exist)
 						assert.Nil(t, v.DeletedTime)
 					}
-
 				}
 			}
 		})

--- a/net/net.go
+++ b/net/net.go
@@ -91,8 +91,9 @@ func CreateMTLSServer(source *workloadapi.X509Source,
 
 	tlsConfig := tlsconfig.MTLSServerConfig(source, source, authorizer)
 	server := &http.Server{
-		Addr:      tlsPort,
-		TLSConfig: tlsConfig,
+		Addr:              tlsPort,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	return server, nil
 }

--- a/net/post.go
+++ b/net/post.go
@@ -71,6 +71,7 @@ func Post(client *http.Client, path string, mr []byte) ([]byte, error) {
 			err,
 		)
 	}
+	defer r.Body.Close()
 
 	if r.StatusCode != http.StatusOK {
 		if r.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
I see that @v0lkan created a PR for linting the code, and I realize that `spike-sdk-go` doesn't have a linter tool.

---

## Changes

- Created a golangci-lint configuration file.
- Blank lines removed.
- Add 10 second ReadHeaderTimeout to avoid Potential [Slowloris Attack](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack)) 
- Close response body after request successfully done

## Questions

- Linter suggests to use `mock.Retrier` rather than `mock.MockRetrier` What are your thoughts?
- Is 10 seconds timeout ok :question: 
- I can add golangci-lint to tools.go and create a script like `hack/lint.sh`
- I can create a CI for linting the app.

just like spike.

## Details

<details>
<summary>All Lint Warnings | Before the changes | `golangci-lint run`</summary>

```shell
api/internal/impl/api/secret/put.go:35:48: unnecessary leading newline (whitespace)
	path string, values map[string]string) error {
	                                              ^
net/net.go:93:13: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
	server := &http.Server{
		Addr:      tlsPort,
		TLSConfig: tlsConfig,
	}
net/post.go:67:21: response body must be closed (bodyclose)
	r, err := client.Do(req)
	                   ^
kv/delete.go:26:25: unnecessary leading newline (whitespace)
	if len(versions) == 0 {
	                       ^
kv/undelete_test.go:183:5: unnecessary trailing newline (whitespace)
				}
				^
retry/mock/mock.go:12:6: exported: type name will be used as mock.MockRetrier by other packages, and that stutters; consider calling this Retrier (revive)
type MockRetrier struct {
     ^
```

</details>


<details>
<summary>All Lint Warnings | After the changes | `golangci-lint run`</summary>

```shell
retry/mock/mock.go:12:6: exported: type name will be used as mock.MockRetrier by other packages, and that stutters; consider calling this Retrier (revive)
type MockRetrier struct {
     ^
```

</details>