### PR TITLE
Add @parlakisik as a Codeowner for SPIKE and SPIKE SDK

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,5 @@
 
 ## Code Owners (in no particular order) ##
 
-* @v0lkan @kfox1111 # Volkan Özçelik and Kevin Fox
+* @v0lkan @kfox1111 @parlakisik # Volkan Özçelik, Kevin Fox, Murat Parlakışık
+


### PR DESCRIPTION
This PR adds @parlakisik as a codeowner for the SPIKE repository.

We are currently collaborating on several new features that require iterative changes and frequent feedback. Given the timezone differences, relying solely on the traditional pull request review workflow has been slowing down development. By making @parlakisik a codeowner, we can:

- Collaborate directly on shared feature branches without waiting for asynchronous PR reviews.
- Maintain high velocity while ensuring code quality through mutual reviews and discussions in real time.
- Distribute ownership and responsibility for maintaining SPIKE’s growing codebase.

This change will help us move faster on critical features while keeping the codebase well-maintained and aligned with SPIKE’s design principles.