### PR TITLE
Add cipher encrypt and decrypt apis into the sdk

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,113 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/spiffe/spike-sdk-go/api/internal/impl/api/cipher"
+)
+
+// stub source (nil pointer acceptable for our stubs)
+var fakeSource *workloadapi.X509Source
+
+func TestAPI_CipherStreamMethods(t *testing.T) {
+	a := NewWithSource(fakeSource)
+
+	// backup and restore
+	origEnc, origDec := cipherEncryptFunc, cipherDecryptFunc
+	t.Cleanup(func() { cipherEncryptFunc, cipherDecryptFunc = origEnc, origDec })
+
+	cipherEncryptFunc = func(_ *workloadapi.X509Source, mode cipher.Mode, r io.Reader, contentType string, _ []byte, _ string) ([]byte, error) {
+		if mode != cipher.ModeStream || contentType != "application/octet-stream" {
+			return nil, errors.New("bad mode or content-type")
+		}
+		b, _ := io.ReadAll(r)
+		if string(b) != "plain" {
+			return nil, errors.New("unexpected input")
+		}
+		return []byte("cipher"), nil
+	}
+	cipherDecryptFunc = func(_ *workloadapi.X509Source, mode cipher.Mode, r io.Reader, contentType string, _ byte, _, _ []byte, _ string) ([]byte, error) {
+		if mode != cipher.ModeStream || contentType != "application/octet-stream" {
+			return nil, errors.New("bad mode or content-type")
+		}
+		b, _ := io.ReadAll(r)
+		if string(b) != "cipher" {
+			return nil, errors.New("unexpected input")
+		}
+		return []byte("plain"), nil
+	}
+
+	out, err := a.CipherEncryptStream(bytes.NewReader([]byte("plain")), "application/octet-stream")
+	if err != nil {
+		t.Fatalf("CipherEncryptStream error: %v", err)
+	}
+	if string(out) != "cipher" {
+		t.Fatalf("unexpected encrypt out: %s", string(out))
+	}
+
+	out2, err := a.CipherDecryptStream(bytes.NewReader([]byte("cipher")), "application/octet-stream")
+	if err != nil {
+		t.Fatalf("CipherDecryptStream error: %v", err)
+	}
+	if string(out2) != "plain" {
+		t.Fatalf("unexpected decrypt out: %s", string(out2))
+	}
+
+	// error path
+	cipherEncryptFunc = func(_ *workloadapi.X509Source, _ cipher.Mode, _ io.Reader, _ string, _ []byte, _ string) ([]byte, error) {
+		return nil, errors.New("boom")
+	}
+	if _, err := a.CipherEncryptStream(bytes.NewReader(nil), "application/octet-stream"); err == nil {
+		t.Fatalf("expected error from CipherEncryptStream")
+	}
+}
+
+func TestAPI_CipherJSONMethods(t *testing.T) {
+	a := NewWithSource(fakeSource)
+
+	origEnc, origDec := cipherEncryptFunc, cipherDecryptFunc
+	t.Cleanup(func() { cipherEncryptFunc, cipherDecryptFunc = origEnc, origDec })
+
+	cipherEncryptFunc = func(_ *workloadapi.X509Source, mode cipher.Mode, _ io.Reader, _ string, plaintext []byte, algorithm string) ([]byte, error) {
+		if mode != cipher.ModeJSON {
+			return nil, errors.New("bad mode")
+		}
+		if string(plaintext) != "p" || algorithm != "alg" {
+			return nil, errors.New("bad input")
+		}
+		return []byte{2}, nil
+	}
+	cipherDecryptFunc = func(_ *workloadapi.X509Source, mode cipher.Mode, _ io.Reader, _ string, version byte, _, _ []byte, algorithm string) ([]byte, error) {
+		if mode != cipher.ModeJSON {
+			return nil, errors.New("bad mode")
+		}
+		if version != 1 || algorithm != "alg" {
+			return nil, errors.New("bad input")
+		}
+		return []byte("p"), nil
+	}
+
+	out, err := a.CipherEncryptJSON([]byte("p"), "alg")
+	if err != nil {
+		t.Fatalf("CipherEncryptJSON error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("unexpected encrypt json response length: %d", len(out))
+	}
+
+	outp, err := a.CipherDecryptJSON(1, []byte{1}, []byte{2}, "alg")
+	if err != nil {
+		t.Fatalf("CipherDecryptJSON error: %v", err)
+	}
+	if string(outp) != "p" {
+		t.Fatalf("unexpected decrypt json: %s", string(outp))
+	}
+}

--- a/api/internal/impl/api/cipher/decrypt.go
+++ b/api/internal/impl/api/cipher/decrypt.go
@@ -1,0 +1,76 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+
+	reqres "github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
+	apiErr "github.com/spiffe/spike-sdk-go/api/errors"
+	"github.com/spiffe/spike-sdk-go/api/url"
+)
+
+// Decrypt decrypts via streaming or JSON based on mode.
+// Stream mode: send r as body with contentType. Returns plaintext bytes.
+// JSON mode: send version, nonce, ciphertext, algorithm; returns plaintext bytes.
+func Decrypt(
+	source *workloadapi.X509Source,
+	mode Mode,
+	r io.Reader,
+	contentType string,
+	version byte,
+	nonce, ciphertext []byte,
+	algorithm string,
+) ([]byte, error) {
+	client, err := createMTLSClient(source)
+	if err != nil {
+		return nil, err
+	}
+
+	switch mode {
+	case ModeStream:
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		rc, err := streamPostWithContentType(client, url.CipherDecrypt(), r, contentType)
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+		b, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+
+	case ModeJSON:
+		payload := reqres.CipherDecryptRequest{Version: version, Nonce: nonce, Ciphertext: ciphertext, Algorithm: algorithm}
+		mr, err := json.Marshal(payload)
+		if err != nil {
+			return nil, errors.Join(errors.New("cipher.Decrypt: marshal request"), err)
+		}
+		body, err := httpPost(client, url.CipherDecrypt(), mr)
+		if err != nil {
+			if errors.Is(err, apiErr.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var res reqres.CipherDecryptResponse
+		if err := json.Unmarshal(body, &res); err != nil {
+			return nil, errors.Join(errors.New("cipher.Decrypt: unmarshal response"), err)
+		}
+		if res.Err != "" {
+			return nil, errors.New(string(res.Err))
+		}
+		return res.Plaintext, nil
+	}
+
+	return nil, errors.New("cipher.Decrypt: unsupported mode")
+}

--- a/api/internal/impl/api/cipher/decrypt_test.go
+++ b/api/internal/impl/api/cipher/decrypt_test.go
@@ -1,0 +1,43 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+func TestDecrypt_OctetStream(t *testing.T) {
+	origCreate := createMTLSClient
+	origPost := streamPost
+	origPostCT := streamPostWithContentType
+	t.Cleanup(func() { createMTLSClient = origCreate; streamPost = origPost; streamPostWithContentType = origPostCT })
+
+	createMTLSClient = func(_ *workloadapi.X509Source) (*http.Client, error) {
+		return &http.Client{}, nil
+	}
+	streamPostWithContentType = func(_ *http.Client, _ string, body io.Reader, ct string) (io.ReadCloser, error) {
+		if ct != "application/octet-stream" {
+			t.Fatalf("unexpected ct: %s", ct)
+		}
+		b, _ := io.ReadAll(body)
+		if string(b) != "cipher" {
+			t.Fatalf("unexpected body: %q", string(b))
+		}
+		return io.NopCloser(bytes.NewReader([]byte("plain"))), nil
+	}
+
+	out, err := Decrypt(nil, ModeStream, bytes.NewReader([]byte("cipher")), "application/octet-stream", 0, nil, nil, "")
+	if err != nil {
+		t.Fatalf("Decrypt error: %v", err)
+	}
+	if string(out) != "plain" {
+		t.Fatalf("unexpected out: %s", string(out))
+	}
+}

--- a/api/internal/impl/api/cipher/encrypt.go
+++ b/api/internal/impl/api/cipher/encrypt.go
@@ -1,0 +1,84 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+
+	reqres "github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
+	apiErr "github.com/spiffe/spike-sdk-go/api/errors"
+	"github.com/spiffe/spike-sdk-go/api/url"
+	"github.com/spiffe/spike-sdk-go/net"
+)
+
+// indirections for testability within this package
+var (
+	createMTLSClient          = net.CreateMTLSClient
+	streamPost                = net.StreamPost
+	streamPostWithContentType = net.StreamPostWithContentType
+	httpPost                  = net.Post
+)
+
+// Encrypt encrypts either via streaming or JSON based on mode.
+// Stream mode: send r as body with contentType. Returns ciphertext bytes.
+// JSON mode: send plaintext + algorithm; returns ciphertext bytes.
+func Encrypt(
+	source *workloadapi.X509Source,
+	mode Mode,
+	r io.Reader,
+	contentType string,
+	plaintext []byte,
+	algorithm string,
+) ([]byte, error) {
+	client, err := createMTLSClient(source)
+	if err != nil {
+		return nil, err
+	}
+
+	switch mode {
+	case ModeStream:
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		rc, err := streamPostWithContentType(client, url.CipherEncrypt(), r, contentType)
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+		b, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+
+	case ModeJSON:
+		payload := reqres.CipherEncryptRequest{Plaintext: plaintext, Algorithm: algorithm}
+		mr, err := json.Marshal(payload)
+		if err != nil {
+			return nil, errors.Join(errors.New("cipher.Encrypt: marshal request"), err)
+		}
+		body, err := httpPost(client, url.CipherEncrypt(), mr)
+		if err != nil {
+			if errors.Is(err, apiErr.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		var res reqres.CipherEncryptResponse
+		if err := json.Unmarshal(body, &res); err != nil {
+			return nil, errors.Join(errors.New("cipher.Encrypt: unmarshal response"), err)
+		}
+		if res.Err != "" {
+			return nil, errors.New(string(res.Err))
+		}
+		return res.Ciphertext, nil
+	}
+
+	return nil, errors.New("cipher.Encrypt: unsupported mode")
+}

--- a/api/internal/impl/api/cipher/encrypt_test.go
+++ b/api/internal/impl/api/cipher/encrypt_test.go
@@ -1,0 +1,53 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(_ *http.Request) (*http.Response, error) { return f(nil) }
+
+func fakeClient(rt http.RoundTripper) *http.Client { return &http.Client{Transport: rt} }
+
+func TestEncrypt_OctetStream(t *testing.T) {
+	origCreate := createMTLSClient
+	origPostCT := streamPostWithContentType
+	origHTTPPost := httpPost
+	t.Cleanup(func() { createMTLSClient = origCreate; streamPostWithContentType = origPostCT; httpPost = origHTTPPost })
+
+	// stub client creation and streaming
+	createMTLSClient = func(_ *workloadapi.X509Source) (*http.Client, error) {
+		return fakeClient(rtFunc(func(_ *http.Request) (*http.Response, error) { return nil, nil })), nil
+	}
+	streamPostWithContentType = func(_ *http.Client, path string, body io.Reader, ct string) (io.ReadCloser, error) {
+		if path == "" {
+			t.Fatalf("empty path")
+		}
+		if ct != "application/octet-stream" {
+			t.Fatalf("unexpected ct: %s", ct)
+		}
+		b, _ := io.ReadAll(body)
+		if string(b) != "plain" {
+			t.Fatalf("unexpected body: %q", string(b))
+		}
+		return io.NopCloser(bytes.NewReader([]byte("cipher"))), nil
+	}
+
+	out, err := Encrypt(nil, ModeStream, bytes.NewReader([]byte("plain")), "application/octet-stream", nil, "")
+	if err != nil {
+		t.Fatalf("Encrypt error: %v", err)
+	}
+	if string(out) != "cipher" {
+		t.Fatalf("unexpected out: %s", string(out))
+	}
+}

--- a/api/internal/impl/api/cipher/mode.go
+++ b/api/internal/impl/api/cipher/mode.go
@@ -1,0 +1,13 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\ SPDX-License-Identifier: Apache-2.0
+
+package cipher
+
+// Mode selects how encrypt/decrypt requests are made to Nexus.
+type Mode string
+
+const (
+	ModeStream Mode = "stream"
+	ModeJSON   Mode = "json"
+)

--- a/net/stream.go
+++ b/net/stream.go
@@ -1,0 +1,62 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package net
+
+import (
+	"errors"
+	"io"
+	"net/http"
+)
+
+// StreamPostWithContentType performs an HTTP POST request with the provided
+// content-type and body and returns the response body as an io.ReadCloser on
+// success. The caller is responsible for closing the returned body.
+//
+// It mirrors error handling of Post: maps common non-200 statuses to well-known
+// errors and ensures response bodies are closed on error.
+func StreamPostWithContentType(client *http.Client, path string, body io.Reader, contentType string) (io.ReadCloser, error) {
+	req, err := http.NewRequest("POST", path, body)
+	if err != nil {
+		return nil, errors.Join(
+			errors.New("streamPost: Failed to create request"),
+			err,
+		)
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	r, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Join(
+			errors.New("streamPost: Problem connecting to peer"),
+			err,
+		)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		defer r.Body.Close()
+
+		if r.StatusCode == http.StatusNotFound {
+			return nil, ErrNotFound
+		}
+		if r.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		if r.StatusCode == http.StatusBadRequest {
+			return nil, ErrBadRequest
+		}
+		if r.StatusCode == http.StatusServiceUnavailable {
+			return nil, ErrNotReady
+		}
+		return nil, errors.New("streamPost: Problem connecting to peer")
+	}
+
+	return r.Body, nil
+}
+
+// StreamPost is a convenience wrapper that posts with
+// Content-Type: application/octet-stream.
+func StreamPost(client *http.Client, path string, body io.Reader) (io.ReadCloser, error) {
+	return StreamPostWithContentType(client, path, body, "application/octet-stream")
+}


### PR DESCRIPTION
Add cipher encrypt and decrypt apis into the sdk

This apis will be used by spike cli commands 
The task : https://github.com/spiffe/spike/issues/193

Signed-off-by: Murat Parlakisik <parlakisik@gmail.com>
